### PR TITLE
Clean up some v0.0.10 cruft

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,9 @@
+Version 0.0.11 (in progress)
+
++ Overhaul support for buildSrc versions eliminating cruft from the code (https://github/msink/libui) used as the model.
+
++ Add a clean target for the root project.
+
 Version 0.0.10 moves to a Gradle multi-project format, adopting the buildSrc concept.
 
 Version 0.0.9 handles parsing invalid JSON strings to a TmdbError object.

--- a/argus-tmdb-core/publish.gradle
+++ b/argus-tmdb-core/publish.gradle
@@ -88,7 +88,7 @@ publishing {
     }
     maven {
       name = 'test'
-      url "file://${rootProject.buildDir}/localMaven"
+      url "file://${rootProject.project("argus-tmdb-core").buildDir}/arguslocalMaven"
     }
   }
 }

--- a/argus-tmdb-core/publish.gradle.kts
+++ b/argus-tmdb-core/publish.gradle.kts
@@ -7,10 +7,10 @@ plugins {
 }
 
 group = Publish.group
-version = Library.version
+version = Versions.argus
 
 fun isReleaseBuild(): Boolean {
-   return !Library.version.contains("SNAPSHOT")
+   return !Versions.argus.contains("SNAPSHOT")
 }
 
 val releaseRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
@@ -18,11 +18,11 @@ val snapshotRepositoryUrl = "https://oss.sonatype.org/content/repositories/snaps
 val repositoryUsername = "${project.property("SONATYPE_NEXUS_USERNAME")}"
 val repositoryPassword = "${project.property("SONATYPE_NEXUS_PASSWORD")}"
 
-tasks.register<Jar>("emptySourcesJar") { classifier = "sources" }
+tasks.register<Jar>("emptySourcesJar") { archiveClassifier.set("sources") }
 
-tasks.register<Jar>("emptyJavadocJar") { classifier = "javadoc" }
+tasks.register<Jar>("emptyJavadocJar") { archiveClassifier.set("javadoc") }
 
-publishing {
+/* publishing {
    repositories {
       maven {
          url  = uri( if (isReleaseBuild()) releaseRepositoryUrl else snapshotRepositoryUrl )
@@ -36,5 +36,4 @@ publishing {
          url  = uri("file://${rootProject.buildDir}/localMaven")
       }
    }
-
-}
+} */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,16 @@
 // SDPX-License-Identifier: LGPL-3.0
 
 plugins {
-    kotlin("multiplatform") version Kotlin.version apply false
-    id("kotlinx-serialization") version Kotlin.version apply false
-    id("com.jfrog.bintray") version Bintray.version apply false
-    jacoco
+    kotlin("multiplatform") version Versions.kotlin apply false
+    id("kotlinx-serialization") version Versions.kotlin apply false
 }
 
 allprojects {
     repositories {
-        if (Kotlin.repo.isNotEmpty()) maven { url = uri(Kotlin.repo) }
         jcenter()
     }
-}
 
-task("clean") {
-    delete(rootProject.buildDir)
+    tasks.register("cleanProject") {
+        delete(project.buildDir)
+    }
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,15 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0
 
-object Kotlin {
-    const val version = "1.3.31"
-    const val repo = "https://dl.bintray.com/kotlin/kotlin-dev"
-}
-
-object Bintray {
-    const val version = "1.8.4-jetbrains-5"
-    const val repo = "https://dl.bintray.com/jetbrains/kotlin-native-dependencies"
-}
-
-object Library {
-    const val version = "0.0.10"
+object Versions {
+    const val kotlin = "1.3.31"
+    const val bintray = "1.8.4"
+    const val argus = "0.0.10"
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,9 +13,6 @@ pluginManagement {
         }
     }
     repositories {
-        if (Kotlin.repo.isNotEmpty()) maven { url = uri(Kotlin.repo) }
-        maven { url = uri(Bintray.repo) }
-        mavenCentral()
         maven { url = uri("https://plugins.gradle.org/m2/") }
     }
 }


### PR DESCRIPTION
This commit cleans up some cruft left in place to ensure that the v0.0.10 code in GitHub and on Maven Central was consistent if not identical. These changes will be part of v0.0.11 when it is released.